### PR TITLE
Replace Hyphenator with CSS-based hyphenation (Fixes #16)

### DIFF
--- a/offenesparlament/static/style/main.css
+++ b/offenesparlament/static/style/main.css
@@ -16,7 +16,7 @@ body {
 
 body, p, li {
   line-height: 1.4em;
-}  
+}
 
 label, input, button, select, textarea {
   font-size: inherit;
@@ -375,7 +375,7 @@ table#factsheet ul {
 
 /* Zitate */
 .result-list.zitate {
-  
+
 }
 
 .result-list.zitate tr td {
@@ -434,6 +434,14 @@ table#factsheet ul {
   margin: 0;
   font-size: 0.9em;
 }
+
+.hyphenate {
+  -webkit-hyphens: auto;
+  -moz-hyphens: auto;
+  -ms-hyphens: auto;
+  hyphens: auto;
+}
+
 
 /* Person */
 .person-foto img {

--- a/offenesparlament/templates/debatte/view.html
+++ b/offenesparlament/templates/debatte/view.html
@@ -32,14 +32,3 @@
   {% endfor %}
 {% endblock %}
 
-{% block script %}
-  <script src="http://assets.pudo.org/libs/hyphenator-4.1.0/hyphenator.js" type="text/javascript">
-  </script>
-  <script type="text/javascript">
-            Hyphenator.run();
-  </script>
-{% endblock %}
-
-
-
-


### PR DESCRIPTION
Only works in some browsers, see
https://developer.mozilla.org/en-US/docs/Web/CSS/hyphens.

Tested in Firefox & Safari, not in IE, Chrome doesn't work.
