### PR TITLE
Docker deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:2.7
+ENV PYTHONUNBUFFERED 1
+
+RUN apt-get update
+RUN apt-get install -y poppler-utils
+
+RUN mkdir /parlament
+WORKDIR /parlament
+COPY pip-requirements.txt /parlament/
+RUN pip install -r pip-requirements.txt
+
+COPY . /parlament
+
+RUN python setup.py develop
+ENV PARLAMENT_SETTINGS settings.py
+CMD ["python", "offenesparlament/manage.py", "runserver", "--host", "0.0.0.0"]
+EXPOSE 5000

--- a/fig.yml
+++ b/fig.yml
@@ -1,0 +1,20 @@
+db:
+  image: postgres
+  ports:
+      - "5432"
+stagingdb:
+  image: postgres
+  ports:
+      - "5432"
+solr:
+  image: milafrerichs/solr-op
+  ports:
+    - "8983"
+web:
+  build: .
+  links:
+      - db
+      - stagingdb
+      - solr
+  ports:
+    - "5000:5000"


### PR DESCRIPTION
## Deployment and Development with Docker

Add Dockerfile and fig.yml for docker deployment
[fig](http://fig.sh) and [docker](http://docker.com) are cool new tools for easy deployment and development.
No need for virtualenv and installing everything locally on your machine. 
## How to run

Install Docker. 
Install fig
`fig build` for setting up the Docker image for offenesparlament
`fig up`for running fig and all images together. like server, databases and solr
## Settings

Settings have to be sepcific to the postgres image

```
SQLALCHEMY_DATABASE_URI = 'postgresql://postgres:postgres@db:5432/postgres'
SOLR_URL = 'http://solr:8983/solr/parlament'
ETL_URL = 'postgresql://postgres:postgres@stagingdb/postgres'
```

Should we set them by default in the default_settings.py @pudo ?
