### PR TITLE
Fix call to process from updater

### DIFF
--- a/offenesparlament/manage.py
+++ b/offenesparlament/manage.py
@@ -10,6 +10,8 @@ from offenesparlament.data.gremien import GREMIUM
 from offenesparlament.data.abstimmungen import ABSTIMMUNG
 from offenesparlament.data.transcripts import TRANSCRIPT
 from offenesparlament.data.ablaeufe import ABLAUF
+import logging
+log = logging.getLogger(__name__)
 
 manager = Manager(app)
 
@@ -76,12 +78,12 @@ def ablaeufe(url=None, force=False, threaded=False, preload=False):
 def update(force=False, threaded=False, preload=False):
     """ Update the entire database. """
     app.config['NOMENKLATURA_PRELOAD'] = not preload
-    engine = etl_engine()
     indexer = get_indexer()
     try:
         for stage in [GREMIUM, PERSON, ABSTIMMUNG, ABLAUF, TRANSCRIPT]:
-            process(engine, indexer, stage, force=force,
+            process(indexer, stage, force=force,
                     threaded=threaded)
+            log.debug("Finish updating: %s" % stage)
     finally:
         indexer.flush()
 


### PR DESCRIPTION
## Updater on manage.py

The updater uses the process function to call all stages that need updates
The process function changed on Dec 23 2012:
https://github.com/okfde/offenesparlament.de/commit/c6f895eac2bac343359d7c34c5d0d0fed6af358b
The process function does not accept the engine anymore
### Removed

Removed the engine
### Changed

changed the call to the the process function
### Added

Added a debugger log to make display which stage is complete.
